### PR TITLE
added cohort stats for new mouse-sc-rnaseq dataset

### DIFF
--- a/src/crn_utils/release_util.py
+++ b/src/crn_utils/release_util.py
@@ -1552,7 +1552,6 @@ def get_cohort_stats_table(dfs: dict[pd.DataFrame], source: str = "pmdbs"):
         report["N_teams"] = N_teams
 
     elif source == "mouse":
-        print("No mouse cohorts yet.")
         datasets = dfs["STUDY"]["ASAP_dataset_id"].unique()
         stat_df = pd.DataFrame()
         for dataset in datasets:


### PR DESCRIPTION
fleshes out the mechanics for the cohort aggregated stats for mouse studies.  The helpers and stub were already made, so it just took a few lines.