### PR TITLE
Feature/refactor prep release

### DIFF
--- a/src/crn_utils/asap_ids.py
+++ b/src/crn_utils/asap_ids.py
@@ -49,7 +49,7 @@ __all__ = [
 ]
 
 
-# The following functions are for generic ID utilities for the Dec2035 refactor
+# The following functions are for generic ID utilities for the Dec2025 refactor
 # to support a unified prep_release_metadata() worfkflow.
 # TODO: Following PRs will handle ID creation and revisit legacy code
 # ----

--- a/src/crn_utils/release_util.py
+++ b/src/crn_utils/release_util.py
@@ -190,6 +190,9 @@ def create_metadata_package(
     write_version(schema_version, os.path.join(final_metadata_path, "cde_version"))
 
 
+
+# !!!NOTE!!! This was used up to and including the December 2025 release. 
+# Importantly, it includes ID generation which is now handled separately.
 ### this is a wrapper to call source specific prep_release_metadata_* functions
 def old_prep_release_metadata(
     ds_path: str | Path,


### PR DESCRIPTION
This is a related follow up to https://github.com/ASAP-CRN/asap-crn-cloud-dataset-metadata/pull/31

It has two main aims:
1. Remove the ID generation step from prep_release_metadata() so that this can be done in a stand-alone script, to help isolate the number of tasks done by this orchestrator
2. Create a single source-agnostic call, rather than dispatch to largely overlapping source-specific functions.

Making this unified also required making universal ID loading/injections calls. I did make a behavior change here, returning a dict holding the mappers rather than return a tuple of mapper. Otherwise, I avoided changing other helpers called for the time being.

Future PRs will:
1. Create a ID generation script in the metadata repo, which may need to be paired with updates to functions in crn_utils.adap_ids.py
2. Refactor the helpers called by prep_release_metadata()
3. Isolate the file_metadata extraction steps, either into a stand-alone script or into the overall prep_dataset_for_release.py worfklow

cc @kfang4 @ergonyc 