### PR TITLE
Feature/feb2026-id-map

### DIFF
--- a/src/crn_utils/asap_ids.py
+++ b/src/crn_utils/asap_ids.py
@@ -56,7 +56,13 @@ __all__ = [
 # to support a unified prep_release_metadata() worfkflow.
 # ID generation and mapping functionality currently wraps existing source-specific
 # functions and leaves these intact for backwards compatibility.
-# TODO: Following PRs will revisit legacy source-specific calls code
+# !!!NOTE!!:
+# FEB2026 release uses CDE v4.1, which has SUBJECT instead of CELL and MOUSE, 
+# meaning subject_id must be unfiform. Further, this release included 
+# schapira-fecal-metagenome-human-baseline, the first non-PMDBS human dataset.
+# For this urgent release we are using the PMDBS ID mappers, but future PRs will
+# 1) Replace the single-source calls with species/source/assay from a universal look up
+# 2) Implement an ID system that best captures non-PMDBS human samples
 # ----
 
 

--- a/src/crn_utils/asap_ids.py
+++ b/src/crn_utils/asap_ids.py
@@ -58,7 +58,7 @@ __all__ = [
 # functions and leaves these intact for backwards compatibility.
 # !!!NOTE!!:
 # FEB2026 release uses CDE v4.1, which has SUBJECT instead of CELL and MOUSE, 
-# meaning subject_id must be unfiform. Further, this release included 
+# meaning subject_id must be uniform. Further, this release included 
 # schapira-fecal-metagenome-human-baseline, the first non-PMDBS human dataset.
 # For this urgent release we are using the PMDBS ID mappers, but future PRs will
 # 1) Replace the single-source calls with species/source/assay from a universal look up

--- a/src/crn_utils/release_util.py
+++ b/src/crn_utils/release_util.py
@@ -111,8 +111,7 @@ def prep_release_metadata(dataset_id: str,
         source=source,
         team=team,
         id_mappers=id_mappers,
-        asap_ids_schema=asap_ids_schema,
-        expected_tables=expected_tables)
+        asap_ids_schema=asap_ids_schema)
     
     logging.info("ASAP IDs injected successfully")
     
@@ -178,12 +177,14 @@ def prep_release_metadata(dataset_id: str,
     
     #  ---- Exporting release metadata ----
     out_dir = dataset_dir / "metadata" / "release" / release_version
-    out_dir.mkdir(parents=False, exist_ok=True)
+    out_dir.mkdir(parents=True, exist_ok=True)
     
     logging.info(f"Exporting release metadata tables to [{out_dir}]...")
     
-    export_meta_tables(updated_meta_tables, out_dir)
-    
+    for table_name, df in updated_meta_tables.items():
+        out_path = out_dir / f"{table_name}.csv"
+        df.to_csv(out_path, index=False, encoding="utf-8")
+
     version_info = f"CDE_VERSION={cde_version}\nRELEASE_VERSION={release_version}\n"
     (out_dir / "VERSION").write_text(version_info)
     

--- a/src/crn_utils/update_schema.py
+++ b/src/crn_utils/update_schema.py
@@ -38,7 +38,6 @@ def get_field_transfer_map() -> pd.DataFrame:
     """
     Dataframe that defines field mappings between old (CDE v3.x) and new (CDE v4.x) schemas.
     Handles two types of transformations:
-    which can be moving fields between tables or renaming a field within a table.
     - Cross-table move: Field moves from one table to another (Old_Table != New_Table)
     - Same-table rename: Field is renamed within the same table (Old_Table == New_Table)
     

--- a/src/crn_utils/util.py
+++ b/src/crn_utils/util.py
@@ -53,6 +53,7 @@ def list_expected_metadata_tables() -> list[str]:
         "PROTOCOL",
         "SUBJECT",
         "SAMPLE",
+        "ASSAY",
         "ASSAY_RNAseq",
         "DATA",
         "PMDBS",
@@ -396,7 +397,7 @@ def export_table(table_name: str, df: pd.DataFrame, out_dir: str):
 def read_meta_table(table_path: str | Path) -> pd.DataFrame:
     # read the whole table
     try:
-        table_df = pd.read_csv(table_path, dtype=str)
+        table_df = pd.read_csv(table_path, encoding="utf-8", dtype=str)
     except UnicodeDecodeError:
         print(f"UnicodeDecodeError: {table_path}")
         table_df = pd.read_csv(table_path, encoding="latin1", dtype=str)
@@ -474,7 +475,9 @@ def load_tables(table_dir: Path, table_names: list[str]) -> dict[str, pd.DataFra
         table_path = table_dir / f"{tab}.csv"
         if not table_path.exists():
             raise FileNotFoundError(f"Table file not found: {table_path}")
-        tables[tab] = read_meta_table(table_path)
+        # TODO: read_meta_table() was propagating latin1 encoding errors
+        # tables[tab] = read_meta_table(table_path)
+        tables[tab] = pd.read_csv(table_path, encoding="utf-8")
     
     return tables
 


### PR DESCRIPTION
## Description

Various hotfixes to allow ID mapping to work with CDE v4.1 and Feb2026 release datasets (tested on team-schapira-fecal-metagenome-human-baseline)
- Treating fecal (human) as PMDBS for this release
- Remove calls to expected tables
- Uniform use of subject_id
- Directly saving out tables as current export table function is introducing encoding issues

## Dependencies (Issues/PRs)

[ClickUp Issue](https://app.clickup.com/t/9014209604/BIOS-2009)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation

## Task Checklist

- [x] Documentation updated

