### PR TITLE
Fix spatial and human-colon definitions

### DIFF
--- a/src/crn_utils/asap_ids.py
+++ b/src/crn_utils/asap_ids.py
@@ -59,12 +59,17 @@ __all__ = [
 # !!!NOTE!!:
 # FEB2026 release uses CDE v4.1, which has SUBJECT instead of CELL and MOUSE, 
 # meaning subject_id must be uniform. Further, this release included 
-# schapira-fecal-metagenome-human-baseline, the first non-PMDBS human dataset.
-# For this urgent release we are using the PMDBS ID mappers, but future PRs will
+# schapira-fecal-metagenome-human-baseline and liddle-human-colon-spatial-cosmx*,
+# the first non-PMDBS human datasets.
+# For this urgent release we are using the PMDBS ID mappers (exceptions_handle_as_pmdbs),
+# but future PRs will:
 # 1) Replace the single-source calls with species/source/assay from a universal look up
 # 2) Implement an ID system that best captures non-PMDBS human samples
 # ----
 
+# TODO: This is a temporary hack for the Feb2026 release and will be replaced in future PRs that look 
+# to implement a more robust ID mapping system and universal look up for species/source/assay 
+exceptions_handle_as_pmdbs = ["pmdbs", "fecal", "human-colon"]
 
 def load_all_id_mappers(map_path: Path, 
                         source: str) -> dict[str, dict]:
@@ -85,7 +90,7 @@ def load_all_id_mappers(map_path: Path,
     if source in ["ipsc", "cell"]:
         source = "invitro"
         
-    if source in ["pmdbs", "fecal"]:
+    if source in exceptions_handle_as_pmdbs:
         source = "pmdbs"
         
     # Dataset is common to all sources
@@ -129,7 +134,7 @@ def update_meta_tables_with_asap_ids(
     if source in ["ipsc", "cell"]:
         source = "invitro"
         
-    if source in ["pmdbs", "fecal"]:
+    if source in exceptions_handle_as_pmdbs:
         source = "pmdbs"
     
     # Getting the individual mappers
@@ -189,7 +194,7 @@ def export_all_id_mappers(
     if source in ["ipsc", "cell"]:
         source = "invitro"
         
-    if source in ["pmdbs", "fecal"]:
+    if source in exceptions_handle_as_pmdbs:
         source = "pmdbs"
         
     # Source-specific exports
@@ -246,7 +251,7 @@ def update_all_id_mappers(
     if source in ["ipsc", "cell"]:
         source = "invitro"
         
-    if source in ["pmdbs", "fecal"]:
+    if source in exceptions_handle_as_pmdbs:
         source = "pmdbs"
         
     logging.info(f"Updating ID mappers for dataset: {dataset_id} of source: {source}")

--- a/src/crn_utils/file_metadata.py
+++ b/src/crn_utils/file_metadata.py
@@ -141,7 +141,7 @@ def update_data_table_with_gcp_uri(data_df: pd.DataFrame, ds_path: str | Path):
 
 
 def update_spatial_table_with_gcp_uri(
-    spatial_df: pd.DataFrame, ds_path: str | Path, visium: bool = True
+    spatial_df: pd.DataFrame, ds_path: str | Path, spatial_subtype: str = "other"
 ):
     """ """
     ds_path = Path(ds_path)
@@ -167,10 +167,14 @@ def update_spatial_table_with_gcp_uri(
     spatial_file_gcp_mapper.update(raw_file_gcp_mapper)
     spatial_file_md5_mapper.update(raw_file_md5_mapper)
 
-    if visium:
+    if spatial_subtype == "visium":
         left_ons = ["visium_cytassist"]
-    else:
+    elif spatial_subtype == "geomx":
         left_ons = ["geomx_config", "geomx_dsp_config", "geomx_annotation_file"]
+    elif spatial_subtype == "cosmx":
+        left_ons = [] # currently no files in SPATIAL table for CosMx datasets
+    else:
+        raise ValueError(f"Unsupported spatial subtype: {spatial_subtype}")
 
     for left_on in left_ons:
         spatial_df[f"{left_on}_md5"] = spatial_df[left_on].map(spatial_file_md5_mapper)


### PR DESCRIPTION
## Fix variable definitions to QC Liddle spatial-cosmx datasets
* Adds `human-colon` to list of exceptions to be temporarily handled as `pmdbs`
* Extends list of spatial datasets (from visium [yes/no] to visium, geomx, cosmx)
* CosMx datasets don't have raw data, then making exception to updated_meta_tables["SPATIAL"]. CosMx files are still shared in raw/ (but no fastq's, etc).
* For future Spatial dataset curations, will need to fix hardcoded dependencies, since current code assumes that there is a SPATIAL table for file_metadata, but SPATIAL is no longer requested un CDE >=4.0

## Dependencies (Issues/PRs)
[ClickUp Issue](https://app.clickup.com/t/86b8gt02v)
[Liddle dataset-meatadata GitHub PR](https://github.com/ASAP-CRN/asap-crn-cloud-dataset-metadata/pull/72)
[Other changes between DEV and PROD Publisher release](https://github.com/ASAP-CRN/asap-crn-cloud-dataset-metadata/pull/77/commits)

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation

## Task Checklist
- [ ] Documentation updated